### PR TITLE
fix: hardcode card image with import in .js file

### DIFF
--- a/src/components/DuckCard.js
+++ b/src/components/DuckCard.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import './styles/DuckCard.css';
+import img from "../images/dog-duck.png";
 
 function DuckCard (props) {
   let { duck }  = props;
   return (
     <div className="duck-card">
       <div className="duck-card__image">
-        <img className="duck-card__png" src={duck.img} alt="" />
+        <img className="duck-card__png" src={img} alt="" />
       </div>
       <div className="duck-card__desc">
         <p className="duck-card__name">


### PR DESCRIPTION
Я не понимаю чего-то. Если я имортирую картинку в карточку утки через import - то на платформе все картинки видны. Правда везде одна и таже картинка (это логично)

А если пути к файлам берутся из `let { duck }  = props;`, то пути остаются отностилельными путями в билде и на платформе ни одна картинка не видна. Нужна помощь. Тут какая-то мелочь, скорее всего, но я уже не знаю, где её искать :(